### PR TITLE
Fix: marketplace publish workflow vsce command not found

### DIFF
--- a/.github/workflows/manual-changeset-publish.yml
+++ b/.github/workflows/manual-changeset-publish.yml
@@ -75,7 +75,7 @@ jobs:
           echo "=========================================="
 
       - name: Run changeset version
-        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != "0" || inputs.force)'
+        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != ''0'' || inputs.force)'
         run: |
           git config user.name "aincrok-bot"
           git config user.email "github-actions@github.com"
@@ -90,18 +90,18 @@ jobs:
           echo "New version: $VERSION"
 
       - name: Create version commit
-        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != "0" || inputs.force)'
+        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != ''0'' || inputs.force)'
         run: |
           git add .
           git commit -m "chore: version bump to ${{ steps.new_version.outputs.new_version }}"
 
       - name: Push changes
-        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != "0" || inputs.force)'
+        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != ''0'' || inputs.force)'
         run: |
           git push
 
       - name: Create GitHub Release
-        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != "0" || inputs.force)'
+        if: '!inputs.dry_run && (steps.check-changesets.outputs.new_changesets != ''0'' || inputs.force)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -106,7 +106,7 @@ jobs:
           echo "=================================="
 
       - name: Build VSIX
-        if: '!inputs.dry_run && (inputs.release_type == "vsix" || inputs.release_type == "both")'
+        if: '!inputs.dry_run && (inputs.release_type == ''vsix'' || inputs.release_type == ''both'')'
         run: |
           pnpm vsix:production
 
@@ -185,7 +185,7 @@ jobs:
           echo "====================================================="
 
       - name: Publish to VS Code Marketplace
-        if: '!inputs.dry_run && (inputs.release_type == "marketplace" || inputs.release_type == "both")'
+        if: '!inputs.dry_run && (inputs.release_type == ''marketplace'' || inputs.release_type == ''both'')'
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
@@ -221,7 +221,7 @@ jobs:
           echo "========================================"
 
       - name: Publish to OpenVSX
-        if: '!inputs.dry_run && (inputs.release_type == "marketplace" || inputs.release_type == "both")'
+        if: '!inputs.dry_run && (inputs.release_type == ''marketplace'' || inputs.release_type == ''both'')'
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |

--- a/src/package.json
+++ b/src/package.json
@@ -612,8 +612,8 @@
 		"format": "prettier --write .",
 		"bundle": "node esbuild.mjs",
 		"vscode:prepublish": "pnpm bundle --production",
-		"vsix": "mkdirp ../bin && vsce package --no-dependencies --out ../bin",
-		"publish:marketplace": "vsce publish --no-dependencies && ovsx publish --no-dependencies",
+		"vsix": "mkdirp ../bin && npx @vscode/vsce package --no-dependencies --out ../bin",
+		"publish:marketplace": "npx @vscode/vsce publish --no-dependencies -p \"$VSCE_PAT\" && npx ovsx publish --no-dependencies -p \"$OVSX_PAT\"",
 		"watch:bundle": "pnpm bundle --watch",
 		"watch:tsc": "cd .. && tsc --noEmit --watch --project src/tsconfig.json",
 		"clean": "rimraf README.md CHANGELOG.md LICENSE dist logs mock .turbo"


### PR DESCRIPTION
This pull request updates the publishing workflow for the VS Code extension by switching to using locally installed publishing tools and explicit authentication tokens. The main changes are focused on improving reliability and security during packaging and publishing.

**Publishing workflow improvements:**

* Updated the `vsix` script to use `npx @vscode/vsce` for packaging, ensuring the correct version of the tool is used regardless of global installation.
* Updated the `publish:marketplace` script to use `npx @vscode/vsce` and `npx ovsx` with explicit authentication tokens (`$VSCE_PAT` and `$OVSX_PAT`), improving security and compatibility with CI/CD environments.